### PR TITLE
Use requestAnimationFrame polyfill to avoid test warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --setupTestFrameworkScriptFile='<rootDir>/shims/requestAnimationFrame.js'",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public"

--- a/shims/requestAnimationFrame.js
+++ b/shims/requestAnimationFrame.js
@@ -1,0 +1,3 @@
+global.requestAnimationFrame = callback => {
+  setTimeout(callback, 0);
+}


### PR DESCRIPTION
This gets rid of a test warning by providing a `requestAnimationFrame` polyfill before the tests are run. This approach was suggested in an issue here: https://github.com/facebook/jest/issues/4545#issuecomment-332762365

The workaround to the `jest` config inside of package.json is to use the `setupTestFrameworkScriptFile` flag when running jest.